### PR TITLE
Fix for packaging

### DIFF
--- a/ac-clang.el
+++ b/ac-clang.el
@@ -1,7 +1,6 @@
-;;; -*- mode: emacs-lisp ; coding: utf-8-unix ; lexical-binding: t -*-
-;;; last updated : 2015/02/16.11:33:45
+;;; ac-clang.el --- Auto Completion source by libclang for GNU Emacs -*- lexical-binding: t; -*-
 
-;;; ac-clang.el --- Auto Completion source by libclang for GNU Emacs
+;;; last updated : 2015/02/16.11:33:45
 
 ;; Copyright (C) 2010       Brian Jiang
 ;; Copyright (C) 2012       Taylan Ulrich Bayirli/Kammer
@@ -1277,3 +1276,5 @@ This variable will typically contain include paths, e.g., (\"-I~/MyProject\" \"-
 
 
 (provide 'ac-clang)
+
+;;; ac-clang.el ends here


### PR DESCRIPTION
- Fix package description
- Add end marker

I fixed for packaging.
First line must be **filename** and **package description**.
(If you enable `lexical-binding`, it must also be defined at first line)

`end marker` must be end of file.
And I remove needless buffer local variable which is major-mode.

パッケージ形式について問題があったので修正しました.
1行目は `ファイル名 --- パッケージの説明`である必要があります(`lexical-binding`の定義は一行目で
なくてはいけないので必要あればパッケージの説明の後ろに定義する)

またファイルの末尾にはエンドマーカが必要になります.
モードのためのバッファローカル変数は不要なので削除しました.

よろしくお願いします.
